### PR TITLE
Make `normalize()` work

### DIFF
--- a/IPLabImageAccess.js
+++ b/IPLabImageAccess.js
@@ -263,7 +263,7 @@ class IPLabImageAccess{
         var min = this.getMin()
         var range = this.getMax() - min
 		// loop through all pixels
-        for(var x = 0; y < this.nx; y++){
+        for(var x = 0; x < this.nx; x++){
             for(var y = 0; y < this.ny; y++){
                 var val = this.getPixel(x, y)
 				// normalize pixel (range = [0,1])


### PR DESCRIPTION
It was testing and incrementing `y` instead of `x` in the outer
loop (note that using `let` instead of `var` as is recommended in modern
JavaScript to declare the variables would have resulted in this code
emitting an error at runtime instead of silently doing the wrong thing).